### PR TITLE
👷‍♀️ Fix logical error

### DIFF
--- a/R/check_course.R
+++ b/R/check_course.R
@@ -40,7 +40,7 @@ check_course = function(course_dir = ".", save_metrics = TRUE,
       warning(paste0("Multiple sheets identified!  Please check ",
                      fname))
     }
-    if (length(x) == 0|grepl("\\(\\)",x)) {
+    if (length(x) == 0 || grepl("\\(\\)", x)) {
       return(NA)
     }
     return(x)


### PR DESCRIPTION
For the line in question, if `x` is actually length 0, it will render an error since it can't `grepl()` on something length 0. Updated `|` ➡️ `||` so it first checks if it is 0 and moves on if so without `grepl()`ing.
