### PR TITLE
only look for youtube URL (and not all PNGs) in `update_youtube_link()`

### DIFF
--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -195,6 +195,10 @@ png_pattern = function() {
          "^!\\[.+\\]\\(https\\:\\/\\/www\\.youtu.+\\)")
 }
 
+yt_pattern = function() {
+  paste0(
+         "^!\\[.+\\]\\(https\\:\\/\\/www\\.youtu.+\\)")
+}
 
 is.Token = function(token) {
   inherits(token, "Token")

--- a/R/check_course.R
+++ b/R/check_course.R
@@ -253,7 +253,7 @@ check_course = function(
   youtube_link_in_md = function(fname, check_youtube_links = TRUE) {
     x = readLines(fname, warn = FALSE)
     # will find better singular regex for this eventually...
-    line <- grep(pattern = png_pattern(),
+    line <- grep(pattern = yt_pattern(),
                  x, perl = TRUE) #
     if (length0(line)) {
       return(NA)
@@ -341,7 +341,7 @@ check_course = function(
     function(fname) {
       x = readLines(fname, warn = FALSE)
       line <-
-        grep(pattern = png_pattern(), x, perl = TRUE)
+        grep(pattern = yt_pattern(), x, perl = TRUE)
       line <-
         line[grep("gif", x[line], invert = TRUE)]
       ## get youtube ID

--- a/R/update_youtube_link.R
+++ b/R/update_youtube_link.R
@@ -60,7 +60,7 @@ update_youtube_link <- function(course_status = NULL,
       message(paste0("Updating youtube link in manuscript file: ", fname))
       txt  <- readLines(fname)
       # identify which link to edit for the video
-      line <- grep(pattern = png_pattern(), txt, perl = TRUE)
+      line <- grep(pattern = yt_pattern(), txt, perl = TRUE)
 
       # replace empty () or (http://etc) with new link
       txt[line] <- gsub("\\(.+\\)|\\(\\)",
@@ -80,7 +80,7 @@ update_youtube_link <- function(course_status = NULL,
     check_urls = mapply(function(fname, new_url) {
       txt  <- readLines(fname)
       # identify which link to edit for the video
-      line <- grep(pattern = png_pattern(), txt, perl = TRUE)
+      line <- grep(pattern = yt_pattern(), txt, perl = TRUE)
       urls <- gsub(".*]\\((.*)\\)","\\1", txt[line])
       urls = unique(urls)
       all(urls %in% new_url)


### PR DESCRIPTION
After we changed to use PNGs from Google Slides, rather than local paths, this was needed.

Before PR: `update_youtube_link` was using `png_pattern()` to search for any PNG link in the file; however, that would find all images and the youtube link we actually want to edit.

Here I:
- added `yt_pattern()` to utils
- used `yt_pattern()` instead of `png_pattern()` in `check_course()` and `update_youtube_link()`
- left `png_pattern()` in utils...but I think it could be removed, if desired